### PR TITLE
Celery Worker 1 doesn't initialize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,6 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
-        command: celery -A run.celery worker --loglevel=info
+        command: celery -A run.celery worker -l INFO
         links:
             - redis


### PR DESCRIPTION
This happen because it uses the latest version of Celery in the requirement.txt